### PR TITLE
bump http package dependency to `^1.1.0`

### DIFF
--- a/microphone_web/pubspec.yaml
+++ b/microphone_web/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
 
-  http: ^0.13.1
+  http: ^1.1.0
 
   microphone_platform_interface: ^0.1.0
 


### PR DESCRIPTION
## Description

many packages now depends on http > `1.0.0`
The current latest version of http is `1.1.2` however it requires higher sdk version, which is >= 3.2.0.
